### PR TITLE
Add command exit codes

### DIFF
--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -12,10 +12,9 @@ declare(strict_types=1);
 namespace Spiral\Console\Command;
 
 use Psr\Container\ContainerInterface;
-use Spiral\Console\Command;
 use Spiral\Console\Config\ConsoleConfig;
 
-final class ConfigureCommand extends Command
+final class ConfigureCommand extends SequenceCommand
 {
     protected const NAME        = 'configure';
     protected const DESCRIPTION = 'Configure project';
@@ -23,24 +22,12 @@ final class ConfigureCommand extends Command
     /**
      * @param ConsoleConfig      $config
      * @param ContainerInterface $container
+     * @return int
      */
-    public function perform(ConsoleConfig $config, ContainerInterface $container): void
+    public function perform(ConsoleConfig $config, ContainerInterface $container): int
     {
         $this->writeln("<info>Configuring project:</info>\n");
 
-        foreach ($config->configureSequence() as $sequence) {
-            $sequence->writeHeader($this->output);
-
-            try {
-                $sequence->execute($container, $this->output);
-                $sequence->whiteFooter($this->output);
-            } catch (\Throwable $e) {
-                $this->sprintf("<error>%s</error>\n", $e);
-            }
-
-            $this->writeln('');
-        }
-
-        $this->writeln('<info>All done!</info>');
+        return $this->runSequence($config->configureSequence(), $container);
     }
 }

--- a/src/Command/SequenceCommand.php
+++ b/src/Command/SequenceCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Spiral\Console\Command;
+
+use Generator;
+use Psr\Container\ContainerInterface;
+use Spiral\Console\Command;
+use Spiral\Console\Config\ConsoleConfig;
+use Symfony\Component\Console\Input\InputOption;
+use Throwable;
+
+abstract class SequenceCommand extends Command
+{
+    public const    OPTIONS = [
+        ['ignore', 'i', InputOption::VALUE_NONE, 'Ignore any errors'],
+        ['break', 'b', InputOption::VALUE_NONE, 'Break on first error, works if ignore is disabled']
+    ];
+
+    /**
+     * @param Generator $commands
+     * @param ContainerInterface $container
+     * @return int
+     */
+    protected function runSequence(Generator $commands, ContainerInterface $container): int
+    {
+        $errors = 0;
+        foreach ($commands as $sequence) {
+            $sequence->writeHeader($this->output);
+
+            try {
+                $sequence->execute($container, $this->output);
+                $sequence->whiteFooter($this->output);
+            } catch (Throwable $e) {
+                $errors++;
+                $this->sprintf("<error>%s</error>\n", $e);
+                if (!$this->option('ignore') && $this->option('break')) {
+                    $this->writeln('<fg=red>Aborting.</fg=red>');
+
+                    return 1;
+                }
+            }
+
+            $this->writeln('');
+        }
+
+        $this->writeln('<info>All done!</info>');
+
+        return ($errors && !$this->option('ignore')) ? 1 : 0;
+    }
+}

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -12,10 +12,9 @@ declare(strict_types=1);
 namespace Spiral\Console\Command;
 
 use Psr\Container\ContainerInterface;
-use Spiral\Console\Command;
 use Spiral\Console\Config\ConsoleConfig;
 
-final class UpdateCommand extends Command
+final class UpdateCommand extends SequenceCommand
 {
     protected const NAME        = 'update';
     protected const DESCRIPTION = 'Update project state';
@@ -23,24 +22,12 @@ final class UpdateCommand extends Command
     /**
      * @param ConsoleConfig      $config
      * @param ContainerInterface $container
+     * @return int
      */
-    public function perform(ConsoleConfig $config, ContainerInterface $container): void
+    public function perform(ConsoleConfig $config, ContainerInterface $container): int
     {
         $this->writeln("<info>Updating project state:</info>\n");
 
-        foreach ($config->updateSequence() as $sequence) {
-            $sequence->writeHeader($this->output);
-
-            try {
-                $sequence->execute($container, $this->output);
-                $sequence->whiteFooter($this->output);
-            } catch (\Throwable $e) {
-                $this->sprintf("<error>%s</error>\n", $e);
-            }
-
-            $this->writeln('');
-        }
-
-        $this->writeln('<info>All done!</info>');
+        return $this->runSequence($config->updateSequence(), $container);
     }
 }

--- a/tests/Console/ConfigureTest.php
+++ b/tests/Console/ConfigureTest.php
@@ -11,11 +11,15 @@ declare(strict_types=1);
 namespace Spiral\Console\Tests;
 
 use Spiral\Console\Command\ConfigureCommand;
+use Spiral\Console\Config\ConsoleConfig;
 use Spiral\Console\Console;
 use Spiral\Console\StaticLocator;
+use Spiral\Console\Tests\Fixtures\AnotherFailedCommand;
+use Spiral\Console\Tests\Fixtures\FailedCommand;
 use Spiral\Console\Tests\Fixtures\HelperCommand;
 use Spiral\Console\Tests\Fixtures\TestCommand;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 class ConfigureTest extends BaseTest
 {
@@ -36,6 +40,9 @@ class ConfigureTest extends BaseTest
         ]
     ];
 
+    /**
+     * @throws Throwable
+     */
     public function testConfigure(): void
     {
         $core = $this->getCore(new StaticLocator([
@@ -62,6 +69,55 @@ exception
 All done!'), trim(str_replace(["\n", "\r", '  '], ' ', $result)));
     }
 
+    /**
+     * @throws Throwable
+     */
+    public function testBreakFailure(): void
+    {
+        $core = $this->bindFailure();
+
+        $output = $core->run('configure', ['--break' => true]);
+        $result = $output->getOutput()->fetch();
+
+        $this->assertStringContainsString('Unhandled failed command error at', $result);
+        $this->assertStringContainsString('Aborting.', $result);
+        $this->assertStringNotContainsString('Unhandled another failed command error at', $result);
+        $this->assertEquals(1, $output->getCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testIgnoreAndBreakFailure(): void
+    {
+        $core = $this->bindFailure();
+
+        $output = $core->run('configure', ['--ignore' => true, '--break' => true]);
+        $result = $output->getOutput()->fetch();
+
+        $this->assertStringContainsString('Unhandled failed command error at', $result);
+        $this->assertStringNotContainsString('Aborting.', $result);
+        $this->assertStringContainsString('Unhandled another failed command error at', $result);
+        $this->assertEquals(0, $output->getCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testNoBreakFailure(): void
+    {
+        $core = $this->bindFailure();
+        $this->container->bind(Console::class, $core);
+
+        $output = $core->run('configure');
+        $result = $output->getOutput()->fetch();
+
+        $this->assertStringContainsString('Unhandled failed command error at', $result);
+        $this->assertStringNotContainsString('Aborting.', $result);
+        $this->assertStringContainsString('Unhandled another failed command error at', $result);
+        $this->assertEquals(1, $output->getCode());
+    }
+
     public function do(OutputInterface $output): void
     {
         $output->write('OK');
@@ -69,7 +125,31 @@ All done!'), trim(str_replace(["\n", "\r", '  '], ' ', $result)));
 
     public function err(OutputInterface $output): void
     {
-        throw new ShortException();
+        throw new ShortException('Failed configure command');
+    }
+
+    /**
+     * @return Console
+     */
+    private function bindFailure(): Console
+    {
+        $core = $this->getCore(new StaticLocator([
+            HelperCommand::class,
+            ConfigureCommand::class,
+            TestCommand::class,
+            FailedCommand::class,
+            AnotherFailedCommand::class,
+        ]));
+        $this->container->bind(ConsoleConfig::class, new ConsoleConfig([
+            'locateCommands' => false,
+            'configure'      => [
+                ['command' => 'failed', 'header' => 'Failed Command'],
+                ['command' => 'failed:another', 'header' => 'Another failed Command'],
+            ]
+        ]));
+        $this->container->bind(Console::class, $core);
+
+        return $core;
     }
 }
 

--- a/tests/Console/CoreTest.php
+++ b/tests/Console/CoreTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace Spiral\Console\Tests;
 
-use Spiral\Console\Command\ReloadCommand;
 use Spiral\Console\StaticLocator;
 use Spiral\Console\Tests\Fixtures\TestCommand;
 use Symfony\Component\Console\Input\ArrayInput;

--- a/tests/Console/Fixtures/AnotherFailedCommand.php
+++ b/tests/Console/Fixtures/AnotherFailedCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Spiral Framework, SpiralScout LLC.
+ *
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Spiral\Console\Tests\Fixtures;
+
+use Exception;
+use Spiral\Console\Command;
+
+class AnotherFailedCommand extends Command
+{
+    public const NAME = 'failed:another';
+
+    /**
+     * @throws Exception
+     */
+    public function perform(): void
+    {
+        throw new Exception('Unhandled another failed command error at ' . __METHOD__ . ' (line ' . __LINE__ . ')');
+    }
+}

--- a/tests/Console/Fixtures/FailedCommand.php
+++ b/tests/Console/Fixtures/FailedCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Spiral Framework, SpiralScout LLC.
+ *
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Spiral\Console\Tests\Fixtures;
+
+use Exception;
+use Spiral\Console\Command;
+
+class FailedCommand extends Command
+{
+    public const NAME = 'failed';
+
+    /**
+     * @throws Exception
+     */
+    public function perform(): void
+    {
+        throw new Exception('Unhandled failed command error at ' . __METHOD__ . ' (line ' . __LINE__ . ')');
+    }
+}


### PR DESCRIPTION
Add return status codes for `update` and `configure` commands to reflect failed status. Related to https://github.com/spiral/framework/issues/234
